### PR TITLE
gpx 파일 업로드 백엔드 구현

### DIFF
--- a/src/main/java/com/dalrun/dao/GpxFilesDao.java
+++ b/src/main/java/com/dalrun/dao/GpxFilesDao.java
@@ -11,5 +11,10 @@ import com.dalrun.dto.GpxFilesDto;
 @Repository
 public interface GpxFilesDao {
 
+	// gpx 파일 리스트 조회
 	List<GpxFilesDto> gpxFilesList();
+	
+	// gpx 파일 정보 삽입
+	int insertGpxFile(GpxFilesDto gpx);
+	
 }

--- a/src/main/java/com/dalrun/dto/CourseDto.java
+++ b/src/main/java/com/dalrun/dto/CourseDto.java
@@ -9,14 +9,13 @@ public class CourseDto implements Serializable{
 	private String level; 		// 난이도
 	private String courseTitle; // 코스 이름
 	private String thumbnail; 	// 코스 썸네일
-	private String gpx; 		// gpx
 	private String content;		// 코스 소개 내용
 	private int star; 			// 평점
 
 	public CourseDto() {
 	}
 
-	public CourseDto(int courseSeq, int areaCode, String level, String courseTitle, String thumbnail, String gpx,
+	public CourseDto(int courseSeq, int areaCode, String level, String courseTitle, String thumbnail,
 			String content, int star) {
 		super();
 		this.courseSeq = courseSeq;
@@ -24,7 +23,6 @@ public class CourseDto implements Serializable{
 		this.level = level;
 		this.courseTitle = courseTitle;
 		this.thumbnail = thumbnail;
-		this.gpx = gpx;
 		this.content = content;
 		this.star = star;
 	}
@@ -67,14 +65,6 @@ public class CourseDto implements Serializable{
 
 	public void setThumbnail(String thumbnail) {
 		this.thumbnail = thumbnail;
-	}
-
-	public String getGpx() {
-		return gpx;
-	}
-
-	public void setGpx(String gpx) {
-		this.gpx = gpx;
 	}
 
 	public String getContent() {

--- a/src/main/java/com/dalrun/dto/CourseReplyDto.java
+++ b/src/main/java/com/dalrun/dto/CourseReplyDto.java
@@ -1,6 +1,6 @@
 package com.dalrun.dto;
 
-import java.sql.Timestamp;
+import java.util.Date;
 
 public class CourseReplyDto {
 
@@ -9,14 +9,14 @@ public class CourseReplyDto {
 	private int crewSeq;	// 크루 번호
 	private String content;	// 댓글 내용
 	private int diarySeq;	// 다이어리 번호
-	private Timestamp wdate;// 작성 일
+	private Date wdate;// 작성 일
 
 
 	public CourseReplyDto() {
 	}
 
 
-	public CourseReplyDto(int dReplySeq, String memId, int crewSeq, String content, int diarySeq, Timestamp wdate) {
+	public CourseReplyDto(int dReplySeq, String memId, int crewSeq, String content, int diarySeq, Date wdate) {
 		super();
 		this.dReplySeq = dReplySeq;
 		this.memId = memId;
@@ -77,12 +77,12 @@ public class CourseReplyDto {
 	}
 
 
-	public Timestamp getWdate() {
+	public Date getWdate() {
 		return wdate;
 	}
 
 
-	public void setWdate(Timestamp wdate) {
+	public void setWdate(Date wdate) {
 		this.wdate = wdate;
 	}
 

--- a/src/main/java/com/dalrun/dto/DiaryDto.java
+++ b/src/main/java/com/dalrun/dto/DiaryDto.java
@@ -10,25 +10,18 @@ public class DiaryDto implements Serializable {
 	private int crewSeq;	// 크루 번호 FK
 	private String title;	// 다이어리 글 제목
 	private String content; // 다이어리 글 내용
-	private String gpx; 	// gpx 파일 내용 전체(xml)
-	private String distance; 	// 거리 기록
-	private String rTime; 	// 측정 시간
 	private Date wdate;	// 다이어리 작성일
 
 	public DiaryDto() {
 	}
 
-	public DiaryDto(int diarySeq, String memId, int crewSeq, String title, String content, String gpx, String distance,
-			String rTime, Date wdate) {
+	public DiaryDto(int diarySeq, String memId, int crewSeq, String title, String content, Date wdate) {
 		super();
 		this.diarySeq = diarySeq;
 		this.memId = memId;
 		this.crewSeq = crewSeq;
 		this.title = title;
 		this.content = content;
-		this.gpx = gpx;
-		this.distance = distance;
-		this.rTime = rTime;
 		this.wdate = wdate;
 	}
 
@@ -70,30 +63,6 @@ public class DiaryDto implements Serializable {
 
 	public void setContent(String content) {
 		this.content = content;
-	}
-
-	public String getGpx() {
-		return gpx;
-	}
-
-	public void setGpx(String gpx) {
-		this.gpx = gpx;
-	}
-
-	public String getDistance() {
-		return distance;
-	}
-
-	public void setDistance(String distance) {
-		this.distance = distance;
-	}
-
-	public String getrTime() {
-		return rTime;
-	}
-
-	public void setrTime(String rTime) {
-		this.rTime = rTime;
 	}
 
 	public Date getWdate() {

--- a/src/main/java/com/dalrun/dto/DiaryReplyDto.java
+++ b/src/main/java/com/dalrun/dto/DiaryReplyDto.java
@@ -1,6 +1,6 @@
 package com.dalrun.dto;
 
-import java.sql.Timestamp;
+import java.util.Date;
 
 public class DiaryReplyDto {
 
@@ -9,14 +9,14 @@ public class DiaryReplyDto {
 	private int crewSeq;	// 크루 번호
 	private String content;	// 댓글 내용
 	private int diarySeq;	// 다이어리 번호
-	private Timestamp wdate;// 작성 일
+	private Date wdate;// 작성 일
 
 	public DiaryReplyDto() {
 		super();
 		// TODO Auto-generated constructor stub
 	}
 
-	public DiaryReplyDto(int dReplySeq, int crewSeq, String content, int diarySeq, String memId, Timestamp wdate) {
+	public DiaryReplyDto(int dReplySeq, int crewSeq, String content, int diarySeq, String memId, Date wdate) {
 		super();
 		this.dReplySeq = dReplySeq;
 		this.crewSeq = crewSeq;
@@ -66,11 +66,11 @@ public class DiaryReplyDto {
 		this.memId = memId;
 	}
 
-	public Timestamp getWdate() {
+	public Date getWdate() {
 		return wdate;
 	}
 
-	public void setWdate(Timestamp wdate) {
+	public void setWdate(Date wdate) {
 		this.wdate = wdate;
 	}
 

--- a/src/main/java/com/dalrun/dto/GpxDataDto.java
+++ b/src/main/java/com/dalrun/dto/GpxDataDto.java
@@ -1,6 +1,5 @@
 package com.dalrun.dto;
 
-import java.sql.Timestamp;
 
 public class GpxDataDto {
 
@@ -12,13 +11,13 @@ public class GpxDataDto {
 	private double latitude;// 초 당 위도
 	private double longitude;// 초 당 경도
 	private double altitude;// 초 당 고도
-	private Timestamp mTime;	// 초 당 시간
+	private String mTime;	// 초 당 시간
 
 	public GpxDataDto() {
 	}
 
 	public GpxDataDto(int dataSeq, int fileSeq, int diarySeq, int courseSeq, String memId, double latitude,
-			double longitude, double altitude, Timestamp mTime) {
+			double longitude, double altitude, String mTime) {
 		super();
 		this.dataSeq = dataSeq;
 		this.fileSeq = fileSeq;
@@ -95,11 +94,11 @@ public class GpxDataDto {
 		this.altitude = altitude;
 	}
 
-	public Timestamp getmTime() {
+	public String getmTime() {
 		return mTime;
 	}
 
-	public void setmTime(Timestamp mTime) {
+	public void setmTime(String mTime) {
 		this.mTime = mTime;
 	}
 

--- a/src/main/java/com/dalrun/dto/GpxFilesDto.java
+++ b/src/main/java/com/dalrun/dto/GpxFilesDto.java
@@ -1,6 +1,6 @@
 package com.dalrun.dto;
 
-import java.sql.Date;
+import java.util.Date;
 
 public class GpxFilesDto {
 
@@ -11,14 +11,14 @@ public class GpxFilesDto {
 	private String filePath;	// gpx 파일 경로
 	private String memId;		// 유저 ID 	   fk
 	private double distance;	// 이동 거리 값
-	private int maxAltitude;	// 최고 고도 값
+	private double maxAltitude;	// 최고 고도 값
 	private Date uploadDate;	// 업로드 시간
 
 	public GpxFilesDto() {
 	}
 
 	public GpxFilesDto(int fileSeq, int diarySeq, int courseSeq, String fileName, String filePath, String memId,
-			double distance, int maxAltitude, Date uploadDate) {
+			double distance, double maxAltitude, Date uploadDate) {
 		super();
 		this.fileSeq = fileSeq;
 		this.diarySeq = diarySeq;
@@ -87,11 +87,11 @@ public class GpxFilesDto {
 		this.distance = distance;
 	}
 
-	public int getMaxAltitude() {
+	public double getMaxAltitude() {
 		return maxAltitude;
 	}
 
-	public void setMaxAltitude(int maxAltitude) {
+	public void setMaxAltitude(double maxAltitude) {
 		this.maxAltitude = maxAltitude;
 	}
 

--- a/src/main/java/com/dalrun/dto/QnaDto.java
+++ b/src/main/java/com/dalrun/dto/QnaDto.java
@@ -1,13 +1,14 @@
 package com.dalrun.dto;
 
 import java.io.Serializable;
+import java.util.Date;
 
 public class QnaDto implements Serializable{
 
 	private int qnaSeq;			// QnA 번호
 	private int category;		// 질문 카테고리
 	private String title;		// 질문 제목
-	private String wdate;		// 작성 일
+	private Date wdate;			// 작성 일
 	private int readcount;		// 조회 수
 	private String question;	// 질문 글 내용
 	private String answer;		// 답변 글 내용
@@ -17,7 +18,7 @@ public class QnaDto implements Serializable{
 	public QnaDto() {
 	}
 
-	public QnaDto(int qnaSeq, int category, String title, String wdate, int readcount, String question, String answer,
+	public QnaDto(int qnaSeq, int category, String title, Date wdate, int readcount, String question, String answer,
 			int auth, int del) {
 		super();
 		this.qnaSeq = qnaSeq;
@@ -55,11 +56,11 @@ public class QnaDto implements Serializable{
 		this.title = title;
 	}
 
-	public String getWdate() {
+	public Date getWdate() {
 		return wdate;
 	}
 
-	public void setWdate(String wdate) {
+	public void setWdate(Date wdate) {
 		this.wdate = wdate;
 	}
 

--- a/src/main/java/com/dalrun/service/GpxFilesService.java
+++ b/src/main/java/com/dalrun/service/GpxFilesService.java
@@ -16,8 +16,15 @@ public class GpxFilesService {
 	@Autowired
 	GpxFilesDao dao;
 
+	// gpx 파일 리스트 조회
 	public List<GpxFilesDto> gpxFilesList() {
 		return dao.gpxFilesList();
+	}
+	
+	// gpx 파일 정보 삽입
+	public boolean insertGpxFile(GpxFilesDto gpx) {
+		int n = dao.insertGpxFile(gpx);
+		return n>0? true : false; 
 	}
 
 }

--- a/src/main/java/sqls/GpxFiles.xml
+++ b/src/main/java/sqls/GpxFiles.xml
@@ -4,9 +4,18 @@
 	
 <mapper namespace="com.dalrun.dao.GpxFilesDao">
 
+	<!-- gpx 파일 리스트 조회 -->
     <select id="gpxFilesList" resultType="com.dalrun.dto.GpxFilesDto">
         SELECT *
         FROM gpxfiles
     </select>
+    
+    <!-- gpx 파일 업로드 -->
+    <insert id="insertGpxFile" parameterType="com.dalrun.dto.GpxFilesDto">
+    	INSERT INTO gpxFiles
+    	(fileName, filePath, memId, uploadDate)
+    	VALUES (#{fileName}, #{filePath}, #{memId}, #{uploadDate})
+    	
+    </insert>
     
 </mapper>


### PR DESCRIPTION
docs: 파일 업로드 과정에서 잘못 설정되어 있는 데이터 타입과 불필요한 컬럼 삭제했어요! course 테이블의 gpx 컬럼, 각 DTO의 시간 관련 데이터 date로 타입 변경

feat: 파일 업로드 시 파일 명을 '유저ID + 업로드 시간' 으로 설정해서 고유 값처럼 넣었고, 데이터 DB에 넣었을 때 잘 들어갔는 지 판단해서 결과 값 리턴하게 구현했어요